### PR TITLE
Update Readme.md to include xterm-color

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,8 +9,10 @@ When prefixed with an M-, that means your meta key. Typically this is your Windo
 ### Installation
 The simplest way to install, in my opinion:
 1. `git clone https://github.com/lisdude/rmoo.git ~/.emacs.d/rmoo`
-2. Add the following to your configuration file:
+2. `git clone https://github.com/atomontage/xterm-color ~/.emacs/xterm-color`
+3. Add the following to your configuration file:
 ```
+(add-to-list 'load-path "~/.emacs.d/xterm-color")
 (add-to-list 'load-path "~/.emacs.d/rmoo")
 (require 'rmoo-autoload)
 (require 'moocode-mode)

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ When prefixed with an M-, that means your meta key. Typically this is your Windo
 ### Installation
 The simplest way to install, in my opinion:
 1. `git clone https://github.com/lisdude/rmoo.git ~/.emacs.d/rmoo`
-2. `git clone https://github.com/atomontage/xterm-color ~/.emacs/xterm-color`
+2. `git clone https://github.com/atomontage/xterm-color.git ~/.emacs.d/xterm-color`
 3. Add the following to your configuration file:
 ```
 (add-to-list 'load-path "~/.emacs.d/xterm-color")


### PR DESCRIPTION
This updates the installation instructions to include downloading the `xterm-color` dependency and adding it to the load-path.
